### PR TITLE
Fix: Remove unnecessary status print in executor

### DIFF
--- a/sources/hellGate.c
+++ b/sources/hellGate.c
@@ -124,7 +124,6 @@ here:	if (ft_strncmp(user_input, "\0", 1) != 0)
 		//check_tokens(tokens_list);
 		executor(tokens_list, envp, user_input);
 		free_all(tokens_list, user_input, NULL);
-		printf("status is: %d\n", status);
 	}
 	return (EXIT_SUCCESS);
 }


### PR DESCRIPTION
This commit removes the unnecessary status print in the executor function. This print was redundant and did not provide any useful information.