### PR TITLE
Fix: Ignore d.type_previous if at the beginning of pipeline

### DIFF
--- a/sources/utils/syntax_builder_utils2.c
+++ b/sources/utils/syntax_builder_utils2.c
@@ -78,8 +78,8 @@ void	words_finder(token_ptr *tk_list, t_var d)
 			|| (*tk_list)->previous->token_type == pipe_token)
 			d.type_previous = (*tk_list)->previous->token_type;
 	}
-	if ((*tk_list)->previous->previous == NULL)
-		d.type_previous = 13;
+	/* if ((*tk_list)->previous->previous == NULL)
+		d.type_previous = 13; */
 	if (types_checker(d, 1, NULL) == true)
 	{
 		if (multiple_quotes_check(d, (*tk_list)) == false)


### PR DESCRIPTION
Resolves an issue where d.type_previous was incorrectly set to 13 when at the beginning of a pipeline, which could lead to incorrect syntax checking.